### PR TITLE
Shelter review delete

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -24,6 +24,12 @@ class ReviewsController < ApplicationController
     redirect_to "/shelters/#{review.shelter.id}"
   end
 
+  def destroy
+    review = Review.find(params[:review_id])
+    Review.destroy(params[:review_id])
+    redirect_to "/shelters/#{review.shelter.id}"
+  end
+
   private
 
   def review_params

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -13,6 +13,7 @@
   <% @shelter.reviews.each do |review| %>
     <section id="review-<%= review.id %>">
       <%= link_to "Edit Review", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit" %>
+      <%= link_to "Delete Review", "/shelters/#{@shelter.id}/reviews/#{review.id}", method: :delete %>
       <%= review.title %>
       <%= review.rating %>
       <%= review.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get '/shelters/:shelter_id/pets/:id/edit', to: 'pets#edit'
 
   get '/shelters/:shelter_id/reviews/new', to: 'reviews#new'
+  delete '/shelters/:shelter_id/reviews/:review_id', to: 'reviews#destroy'
   patch '/shelters/:shelter_id/reviews/:review_id', to: 'reviews#update'
   get '/shelters/:shelter_id/reviews/:review_id/edit', to: 'reviews#edit'
   post '/shelters/:shelter_id', to: 'reviews#create'

--- a/spec/features/reviews/delete_spec.rb
+++ b/spec/features/reviews/delete_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe "When I visit a shelter's show page" do
+  describe "Shelter review delete" do
+    before(:each) do
+      @shelter_1 = Shelter.create(name: "Gimme Shelter", address: "5218 Rolling Stones Avenue", city: "Denver", state: "CO", zip: 80203)
+      @review_1 = @shelter_1.reviews.create!(
+        title: "It was good",
+        rating: 4,
+        content: "The staff was really helpful and the adoption process was seamless",
+        image: "https://wordpress.accuweather.com/wp-content/uploads/2019/07/animal-shelter-arkansas.jpg")
+
+      @review_2 = @shelter_1.reviews.create!(
+        title: "Perfectly adequate",
+        rating: 3,
+        content: "Run of the mill shelter")
+
+        visit "/shelters/#{@shelter_1.id}"
+    end
+
+    it "I see a link next to each shelter review to delete that review, and when clicked, the review is destroyed." do
+      within "#review-#{@review_2.id}" do
+        click_link "Delete Review"
+      end
+
+      expect(current_path).to eq("/shelters/#{@review_1.shelter.id}")
+      expect(page).to_not have_content("Perfectly adequate")
+      expect(page).to_not have_content("Run of the mill shelter")
+    end
+
+    it "I can see the remaining, undeleted reviews" do
+      within "#review-#{@review_1.id}" do
+      expect(page).to have_content("It was good")
+      expect(page).to have_content("The staff was really helpful and the adoption process was seamless")
+      expect(page).to have_css("img[src*='#{@review_1.image}']")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Delete a Shelter Review

As a visitor,
When I visit a shelter's show page,
I see a link next to each shelter review to delete the review.
When I delete a shelter review I am returned to the shelter's show page
And I should no longer see that shelter review