### PR TITLE
Pets with approved applications cannot be deleted

### DIFF
--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -23,7 +23,9 @@
             <p>Current Shelter: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %></p>
             <p><%= link_to "Edit", "/pets/#{pet.id}/edit" %> <%= pet.name %></p>
           <% end %>
-          <p><%= link_to "Delete", "/pets/#{pet.id}", method: :delete %> <%= pet.name %></p>
+          <% if pet.adoptable? %>
+            <p><%= link_to "Delete", "/pets/#{pet.id}", method: :delete %> <%= pet.name %></p>
+          <% end %>
         </section>
       </section>
     <% end %>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -12,7 +12,9 @@
         <p>On hold for <%= link_to @pet.applicant_name(@pet.id), "/applications/#{@pet.applicant_id(@pet.id)}" %></p>
       <% end %>
     <p><%= link_to "Edit #{@pet.name}", "/pets/#{@pet.id}/edit" %></p>
-    <p><%= link_to "Delete #{@pet.name}", "/pets/#{@pet.id}", method: :delete %></p>
+    <% if @pet.adoptable? %>
+      <p><%= link_to "Delete #{@pet.name}", "/pets/#{@pet.id}", method: :delete %></p>
+    <% end %>
     <% if favorites.included_in_favorites?(@pet.id) %>
       <p><%= button_to "Remove #{@pet.name} from Favorites", "/favorites/#{@pet.id}", method: :delete %></p>
     <% else %>

--- a/spec/features/pets/destroy_spec.rb
+++ b/spec/features/pets/destroy_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe "when I visit a pet show page" do
-    before :each do
-    @boulder_bulldog_rescue = Shelter.create!(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
-    @henri = @boulder_bulldog_rescue.pets.create!(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
-                        name: 'Henri',
-                        description: "With his heartwarming wrinkles and furrowed brow, he'll slobber his way into your heart!",
-                        approximate_age: 5,
-                        sex: 'Male')
+  before :each do
+  @boulder_bulldog_rescue = Shelter.create!(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
+  @henri = @boulder_bulldog_rescue.pets.create!(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+                      name: 'Henri',
+                      description: "With his heartwarming wrinkles and furrowed brow, he'll slobber his way into your heart!",
+                      approximate_age: 5,
+                      sex: 'Male')
 
-    visit "/pets/#{@henri.id}"
-    end
-    it "I can click a link that deletes that pet" do
+  visit "/pets/#{@henri.id}"
+  end
+
+  it "I can click a link that deletes that pet" do
     click_link "Delete #{@henri.name}"
 
     expect(current_path).to eq("/pets")
@@ -19,5 +20,42 @@ RSpec.describe "when I visit a pet show page" do
     expect(page).to_not have_content(@henri.name)
     expect(page).to_not have_content(@henri.approximate_age)
     expect(page).to_not have_content(@henri.sex)
+  end
+
+  it "I cannot delete a pet who has an approved application" do
+    pet = @boulder_bulldog_rescue.pets.create!(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+                        name: 'Pet 1',
+                        description: "With his heartwarming wrinkles and furrowed brow, he'll slobber his way into your heart!",
+                        approximate_age: 5,
+                        sex: 'Male')
+
+    application = pet.applications.create!( name: "John Doe",
+                                              address: "9827 Denver Drive",
+                                              city:"Denver" ,
+                                              state: "CO",
+                                              zip: 80204,
+                                              phone_number: 2938193029,
+                                              description: "Looking for a furry friend")
+
+    visit "/applications/#{application.id}"
+    within "#pets_applied_for-#{pet.id}" do
+      click_link "Approve Application For #{pet.name}"
+    end
+
+    visit "/pets"
+    within "#pet-#{pet.id}" do
+      expect(page).to_not have_link("Delete")
+    end
+
+    visit "/pets/#{pet.id}"
+    expect(page).to_not have_link("Delete #{pet.name}")
+
+    visit "/shelters/#{@boulder_bulldog_rescue.id}/pets"
+    within "#pet-#{pet.id}" do
+      expect(page).to_not have_link("Delete")
+    end
+
+    visit "/shelters/#{@boulder_bulldog_rescue.id}/pets/#{pet.id}"
+    expect(page).to_not have_link("Delete")
   end
 end

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -150,14 +150,6 @@ RSpec.describe "pets index page" do
       end
       expect(current_path).to eq("/pets")
       expect(page).to_not have_content(@alfred.name)
-
-      visit '/pets'
-
-      within "#pet-#{@botox.id}" do
-        click_link "Delete"
-      end
-      expect(current_path).to eq("/pets")
-      expect(page).to_not have_content(@botox.name)
     end
 
     it "I see adoptable pets listed before pets whose adoption status is pending" do


### PR DESCRIPTION
* Removed test data that incorrectly made test fail
* Added test that visitor cannot delete pet with an approved application
* Added conditionals to pets index and pets show so that delete link does not appear when pet has an approved application
* All tests passing